### PR TITLE
7.x shared canvas changes to coding standards and current islandora implementation.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,6 +1,23 @@
+SUMMARY
+-------
+
 Adds the ability to add annotations to images.  This solution pack piggy backs
 on top of other Islandora Solution Packs such as basic_image and large_image by 
 adding a new tab to existing views.  This tab includes the annotation tools.
+
+
+REQUIREMENTS
+------------
+
+INSTALLATION
+------------
+
+Google Analytics tracking should be setup independent of this reporting aspect. A Google Analytics module is available for tracking
+(http://www.drupal.org/project/google_analytics).
+
+
+CONFIGURATION
+-------------
 
 To enable the annotation tab for a content model visit the Islandora admin section
 and choose Image annotation.  From there you can choose which CModels you want 
@@ -12,6 +29,10 @@ for categories.
 Annotation categories also depend on the selected radio button under Annotation 
 Categories.  If you want to depend on taxonomies choose administrator defined.
 
+
+CUSTOMIZATION
+-------------
+
 Searching:
 Included is an xslt designed for gsearch.  If this xslt is included in your existing 
 gsearch index xslt it will index the Annotation fields and make them searchable 
@@ -21,3 +42,13 @@ have to update them as well.
 
 If you have solr configured properly and have Annotation Categories set as user 
 defined you will have a type ahead for the Annotations categories section.
+
+TROUBLESHOOTING
+---------------
+
+
+F.A.Q.
+------
+
+If you want the annotations for book, do not check the book content model on the admin page. In order 
+for annotations for book you check the paged content model.

--- a/islandora_image_annotation.install
+++ b/islandora_image_annotation.install
@@ -9,16 +9,19 @@
  * Implements hook_requirements().
  */
 function islandora_image_annotation_requirements($phase) {
+  $requirements = array();
   if ($phase == 'install') {
     module_load_include('inc', 'islandora', 'includes/tuque');
     if (!IslandoraTuque::exists()) {
-      return array(array(
-          'title' => 'Tuque',
+      $requirements['tuque_library'] = array(
+       'title' => 'Tuque',
           'description' => 'The Islandora Basic Image solution pack requires the Tuque library.',
           'severity' => REQUIREMENT_ERROR,
-          ));
+      );
     }
+   
   }
+  return $requirements;
 }
 
 /**

--- a/islandora_image_annotation.module
+++ b/islandora_image_annotation.module
@@ -277,29 +277,28 @@ function islandora_image_annotation_preprocess_islandora_image_annotation_solr(&
 /**
  * Implements hook_islandora_required_objects().
  */
-function islandora_image_annotation_islandora_required_objects() {
-  // module path
+function islandora_image_annotation_islandora_required_objects(IslandoraTuque $connection) {
+  
   $module_path = drupal_get_path('module', 'islandora_image_annotation');
-
+  // OAC Content Model
+  $oac_content_model = $connection->repository->constructObject('islandora:OACCModel');
+  $oac_content_model->owner = 'fedoraAdmin';
+  $oac_content_model->label = 'Islandora Annotation CModel';
+  $oac_content_model->models = 'fedora-system:ContentModel-3.0';
+  
+  // DS-COMPOSITE-MODEL Datastream
+  $datastream = $oac_content_model->constructDatastream('DS-COMPOSITE-MODEL', 'X');
+  $datastream->label = 'DS-COMPOSITE-MODEL';
+  $datastream->mimetype = 'text/xml';
+  $datastream->setContentFromFile("$module_path/xml/islandora_image_annotation_ds_composite_model.xml", FALSE);
+  $oac_content_model->ingestDatastream($datastream);
+  
   return array(
-    'islandora_image_annotation' => array(
+  'islandora_image_annotation' => array(
       'title' => 'Islandora image annotations',
       'objects' => array(
-        array(
-          'pid' => 'islandora:OACCModel',
-          'label' => 'Islandora Annotation CModel',
-          'cmodel' => 'fedora-system:ContentModel-3.0',
-          'datastreams' => array(
-            array(
-              'dsid' => 'DS-COMPOSITE-MODEL',
-              'label' => 'DS-COMPOSITE-MODEL',
-              'mimetype' => 'text/xml',
-              'control_group' => 'X',
-              'datastream_file' => "$module_path/xml/islandora_image_annotation_ds_composite_model.xml",
-            ),
-          ),
-        ),
-      ),
-    ),
+        $oac_content_model,
+      )
+    )
   );
 }


### PR DESCRIPTION
Made changes to the required objects.  This had to change because we are now passing fedora objects for the required objects instead of arrays.

I also updated the README file to current coding standards
