### PR TITLE
Fix ISLANDORA-1187

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -387,7 +387,7 @@ function islandora_image_annotation_get_types() {
   $solr = variable_get('islandora_solr_url', 'localhost:8080/solr');
   $solr_url = url($solr . '/select', array('query' => $data));
   $result_request = drupal_http_request($solr_url);
-  // Test whether the reponse status code is 200
+  // Test whether the reponse status code is 200.
   if ($result_request->code == 200) {
     $results = json_decode($result_request->data, TRUE);
     $types = array();
@@ -402,8 +402,7 @@ function islandora_image_annotation_get_types() {
   }
   else {
     return array();
-  }
-  
+  } 
 }
 
 /**

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -387,16 +387,23 @@ function islandora_image_annotation_get_types() {
   $solr = variable_get('islandora_solr_url', 'localhost:8080/solr');
   $solr_url = url($solr . '/select', array('query' => $data));
   $result_request = drupal_http_request($solr_url);
-  $results = json_decode($result_request->data, TRUE);
-  $types = array();
-  if (isset($results['response']['docs'])) {
-    foreach ($results['response']['docs'] as $doc) {
-      $types[] = $doc[$solr_field];
+  // Test whether the reponse status code is 200
+  if ($result_request->code == 200) {
+    $results = json_decode($result_request->data, TRUE);
+    $types = array();
+    if (isset($results['response']['docs'])) {
+      foreach ($results['response']['docs'] as $doc) {
+        $types[] = $doc[$solr_field];
+      }
     }
+    $types = array_unique($types);
+    sort($types, SORT_STRING);
+    return $types;
   }
-  $types = array_unique($types);
-  sort($types, SORT_STRING);
-  return $types;
+  else {
+    return array();
+  }
+  
 }
 
 /**

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -402,7 +402,7 @@ function islandora_image_annotation_get_types() {
   }
   else {
     return array();
-  } 
+  }
 }
 
 /**


### PR DESCRIPTION
Tried to fix https://jira.duraspace.org/browse/ISLANDORA-1187
The cause for this error is that the default 'RELS_EXT_isAnnotationType_literal_s' may not exist in solr on the server and the admin may not know the correct solr field to use for 'Annotation type search field' in config page before the first image annotation being created.  
