### PR TITLE
Fixes https://jira.duraspace.org/browse/ISLANDORA-1271

### DIFF
--- a/js/islandora_image_annotation_canvas.js
+++ b/js/islandora_image_annotation_canvas.js
@@ -285,9 +285,9 @@
 
       paper = new ScaleRaphael(svgId, dimensions.width, dimensions.height);
       paper.changeSize(scaled.width, scaled.height, false, false);
-      if ($.browser.webkit) {
-        paper.safari();
-      }
+      //paper.safari() can be called without previous Browser detection. Raphael does this check.
+      paper.safari();
+      
       // Cache svgCanvas.
       that.raphaels[type][canvas] = paper;
       return paper;

--- a/js/islandora_image_annotation_dialog.js
+++ b/js/islandora_image_annotation_dialog.js
@@ -316,9 +316,21 @@
         svgEncoding.setAttribute('content', 'utf-8');
         svgAbout.appendChild(svgEncoding);
       });
-      // XXX: Need to handle the output this way because of IE browser
-      // incompatabilities.
-      return $(xmldoc.documentElement).html();
+      
+      // Test browser features and call correct to string method
+      var serializeXmlComp = function(xmldoc) {
+        if (typeof window.XMLSerializer != "undefined") {
+          return (new window.XMLSerializer()).serializeToString( xmldoc );
+        } else if (typeof xmldoc.xml != "undefined") {
+          return xmldoc.xml;
+        }
+        return "";
+      }
+ 
+      // convert XML DOM document to string
+      var xmlAsString = serializeXmlComp( xmldoc );
+
+      return xmlAsString;
     };
 
     /**


### PR DESCRIPTION
Makes xml to string, when saving annotation, compatible with iexplorer8, 9 and 10, restores Webkit and Firefox lost functionality. Also removed a deprecated $.browser check. Fixes https://jira.duraspace.org/browse/ISLANDORA-1271
