### PR TITLE
Adds a new button that toggles the display of all annotations.

### DIFF
--- a/css/islandora_image_annotation.base.css
+++ b/css/islandora_image_annotation.base.css
@@ -16,7 +16,8 @@
   height: 100%;
 }
 
-#islandora-image-annotation-full-window-button {
+#islandora-image-annotation-full-window-button,
+#islandora-image-annotation-toggle-annotation-display-button {
   float: right;
   margin: 5px 5px 5px 15px;
 }

--- a/js/islandora_image_annotation_buttons.js
+++ b/js/islandora_image_annotation_buttons.js
@@ -110,4 +110,42 @@
     }
   };
 
+
+  /**
+   * Toggle the display of all Annotations.
+   *
+   * @type {{attach: attach}}
+   */
+  Drupal.behaviors.islandoraImageAnnotationToggleAnnotationDisplay = {
+    attach: function (context) {
+      var base = '#islandora-image-annotation-toggle-annotation-display-button';
+      $(base, context).once('islandoraImageAnnotationToggleAnnotationDisplay', function () {
+        var that = this;
+        // Conditionally change the label of the button depending on if any
+        // annotations are being displayed or not.
+        Drupal.IslandoraImageAnnotation.on('showAnnotation', function (event, annotation) {
+          $(that).text(Drupal.t('Hide Annotation(s)'));
+        });
+
+        Drupal.IslandoraImageAnnotation.on('hideAnnotation', function (event, annotation) {
+          var list = Drupal.IslandoraImageAnnotationList.getInstance();
+          if (!list.isAnyAnnotationDisplayed()) {
+            $(that).text(Drupal.t('Show Annotation(s)'));
+          }
+        });
+
+        // When clicked toggle the display of annotations depending on if any
+        // are showing.
+        $(this).click(function () {
+          var list = Drupal.IslandoraImageAnnotationList.getInstance();
+          if (list.isAnyAnnotationDisplayed()) {
+            list.hideAllAnnotations();
+          }
+          else {
+            list.showAllAnnotations();
+          }
+        });
+      });
+    }
+  };
 }(jQuery));

--- a/js/islandora_image_annotation_list.js
+++ b/js/islandora_image_annotation_list.js
@@ -196,6 +196,24 @@
       if (annotation) {
         canvas.drawAnnotation(annotation);
       }
+      Drupal.IslandoraImageAnnotation.trigger('showAnnotation', annotation || id);
+    },
+
+    /**
+     * Shows all annotations.
+     *
+     * Shows the comment text section of the annotation and the annotation color
+     * icon, also displays the annotation shapes on the canvas for each
+     * annotation.
+     */
+    showAllAnnotations: function () {
+      var that = this;
+      $(".canvas-annotation[annotation]", this.base).each(function () {
+        var id = $(this).attr('annotation');
+        that.showAnnotation(id);
+      });
+      // Open type containers as well.
+      $('.comment-type-content', this.base).show();
     },
 
     /**
@@ -215,6 +233,23 @@
       if (annotation) {
         canvas.hideAnnotation(annotation);
       }
+      Drupal.IslandoraImageAnnotation.trigger('hideAnnotation', annotation || id);
+    },
+
+    /**
+     * Hides all annotations.
+     *
+     * Hides the comment text section of the annotation and the annotation color
+     * icon, also the annotation shapes on the canvas for each annotation.
+     */
+    hideAllAnnotations: function () {
+      var that = this;
+      $(".canvas-annotation[annotation]", this.base).each(function () {
+        var id = $(this).attr('annotation');
+        that.hideAnnotation(id);
+      });
+      // Close type containers as well.
+      $('.comment-type-content', this.base).hide();
     },
 
     /**
@@ -235,6 +270,33 @@
         $('.comment-show-hide', $annotation).text('+');
         that.hideAnnotation(id);
       }
+    },
+
+    /**
+     * Checks if the given annotation is currently visible.
+     *
+     * @param id
+     *   The id of the annotation to check.
+     */
+    isAnnotationDisplayed: function (id) {
+      var $annotation = this.getAnnotationElement(id);
+      return $('.comment-title', $annotation).hasClass('annotation-opened');
+    },
+
+    /**
+     * Checks if any annotation is currently being displayed.
+     */
+    isAnyAnnotationDisplayed: function () {
+      var that = this,
+          any_displayed = false;
+      $(".canvas-annotation[annotation]", this.base).each(function () {
+        var id = $(this).attr('annotation');
+        if (that.isAnnotationDisplayed(id)) {
+          any_displayed = true;
+          return false;
+        }
+      });
+      return any_displayed;
     },
 
     /**

--- a/theme/islandora-image-annotation.tpl.php
+++ b/theme/islandora-image-annotation.tpl.php
@@ -19,6 +19,7 @@
       <button id="islandora-image-annotation-create-annotation-button"><?php print t('Annotate'); ?></button>
     <?php endif; ?>
     <button id="islandora-image-annotation-full-window-button"><?php print t('Full Window'); ?></button>
+    <button id="islandora-image-annotation-toggle-annotation-display-button" value="show"><?php print t('Show Annotation(s)'); ?></button>
     <div class="clearfix"></div>
     <?php print $canvas; ?>
     <?php print $logo; ?>


### PR DESCRIPTION
JIRA Ticket: https://jira.duraspace.org/browse/ISLANDORA-1912

# What does this Pull Request do?

Adds a new button that toggles the display of all annotations, either showing or hiding them.

# What's new?

New button in the interface and some underlying javascript to support its functionality. When no annotations are displayed the button will trigger the display of all the annotations. When any annotations are displayed the button hides the currently displayed annotations. The text it displays matches the behaviour of the those two states.

# How should this be tested?

1. Install the module in the usual way
2. Go to the admin/islandora/tools/image_annotation page and enable image annotations for  your chosen content model (**islandora:sp_large_image_cmodel** for example), using a datastream that can be displayed in the browser (**JPG** for example).
3. Visit an object of your chosen content model and click on the Image Annotation tab.
4. Confirm the button behaves as expected.

# Interested parties

@Islandora/7-x-1-x-committers